### PR TITLE
fix comments in json parse failed

### DIFF
--- a/lib/sort-json.js
+++ b/lib/sort-json.js
@@ -7,11 +7,11 @@ function getConfig() {
 }
 
 function getSelection(textEditor, startLine, endLine) {
-    var selectedText = '';
+    var selectedLines = [];
     for (var i = startLine; i <= endLine; ++i) {
-        selectedText += textEditor.document.lineAt(i).text;
+        selectedLines.push(textEditor.document.lineAt(i).text);
     }
-    return selectedText;
+    return selectedLines.join('\n');
 };
 
 function findIndent(textEditor) {


### PR DESCRIPTION
Fix comments in json files will throw invalid json exception.

```
// comments of start line
{
    // inline comments
    "editor.formatOnType": true,
    "editor.wrappingColumn": 200
}
// comments of end line
````