### PR TITLE
remove trailing commas if they exist from selectedText

### DIFF
--- a/lib/sort-json.js
+++ b/lib/sort-json.js
@@ -66,6 +66,12 @@ function setSelection(textEditor, startLine, startPos, endLine, endPos, sortedTe
     });
 }
 
+function removeTrailingCommas(input) {
+    input = input.replace(/,[ \t\r\n]+}/g, '}');
+    input = input.replace(/,[ \t\r\n]+\]/g, ']');
+    return input;
+}
+
 function sortActiveSelectionInternal(jsonParser, sortOrder) {
     var textEditor = vscode.window.activeTextEditor;
     var selection = textEditor.selection;
@@ -89,6 +95,7 @@ function sortActiveSelectionInternal(jsonParser, sortOrder) {
     var sortOptions = getConfig();
 
     var selectedText = getSelection(textEditor, startLine, startPos, endLine, endPos);
+    selectedText = removeTrailingCommas(selectedText);
     var initialJSON = sorter.textToJSON(jsonParser, selectedText);
     var sortedJSON = sorter.sortJSON(initialJSON, sortOrder, sortOptions);
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,34 @@
                     "description": "Settings to underride the sort order (i.e. to be at the end of the order)"
                 }
             }
+        },
+        "menus": {
+            "editor/context": [
+                {
+                    "command": "sortJSON.sortJSON",
+                    "group": "7_modification",
+                    "title": "Sort JSON",
+                    "when": "editorLangId == json"
+                },
+                {
+                    "command": "sortJSON.sortJSON",
+                    "group": "7_modification",
+                    "title": "Sort JSON",
+                    "when": "editorLangId == jsonc"
+                },
+                {
+                    "command": "sortJSON.sortJSONReverse",
+                    "group": "7_modification",
+                    "title": "Sort JSON (reverse)",
+                    "when": "editorLangId == json"
+                },
+                {
+                    "command": "sortJSON.sortJSONReverse",
+                    "group": "7_modification",
+                    "title": "Sort JSON",
+                    "when": "editorLangId == jsonc"
+                } 
+            ]
         }
     }
 }


### PR DESCRIPTION
```json
{
    "standard.semistandard": true, 
    "ruby.lint": {
        "rubocop": true
    },
}
```

was turning into

```json
{
    "ruby.lint": {
        rubocop: true
    },
    "standard.semistandard": true
}
```
this fixes that, but I don't think this is the best approach (using regex on a JSON).

for example: this will get mangled:
```json
{
    "foo": ", }" 
}
```