### PR TITLE
Make it more a formatter

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+    "tabWidth": 4,
+    "semi": true,
+    "trailingComma": "none"
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# What is it?
+# VSCode SortJSON
+
+## What is it?
 
 Alphabetically sorts the keys in _selected_ JSON objects.
 
@@ -6,36 +8,69 @@ Alphabetically sorts the keys in _selected_ JSON objects.
 
 <a target="_blank" href="https://www.buymeacoffee.com/richie5um"><img src="resources/buymeacoffee.png" alt="Buy me a coffee"></a>
 
-# Install
+## Install
 
-* Install via VSCode extensions install
+- Install via VSCode extensions install
 
-# Usage
+## Usage
 
-* Select a JSON object (note, it uses full lines so ensure the selected lines are a valid JSON object)
-* Run the extension (Cmd+Shift+P => Sort JSON)
+- Select a JSON object (note, it uses full lines so ensure the selected lines are a valid JSON object)
+- Run the extension (Cmd+Shift+P => Sort JSON)
 
-# Updates
+## Updates
 
-* 1.17.0: Sort by type (experimental code).
-* 1.16.0: Sort by values (experimental code).
-* 1.15.0: Change algorithm to better cope with JSON quirks.
-* 1.14.0: Sortable alphanumerically (a2 < a10).
-* 1.13.0: Sortable by key length.
-* 1.12.0: Improvements to JSONC comment detecion - thanks 'reporter123'.
-* 1.11.0: Tries to use normal JSON outputter for some known JSON issues.
-* 1.10.1: Removes (simple) comment lines from JSON before sorting.
-* 1.9.2:  Now sorts the whole file if there is no selected text.
-* 1.9.0:  Now sorts selected JSON text, even if that is embedded in a JSON object - note, doesn't preserve indents.
-* 1.8.0:  Sorts objects within arrays.
+- 1.18.0: Works as a formatter also.
+- 1.17.0: Sort by type (experimental code).
+- 1.16.0: Sort by values (experimental code).
+- 1.15.0: Change algorithm to better cope with JSON quirks.
+- 1.14.0: Sortable alphanumerically (a2 < a10).
+- 1.13.0: Sortable by key length.
+- 1.12.0: Improvements to JSONC comment detecion - thanks 'reporter123'.
+- 1.11.0: Tries to use normal JSON outputter for some known JSON issues.
+- 1.10.1: Removes (simple) comment lines from JSON before sorting.
+- 1.9.2: Now sorts the whole file if there is no selected text.
+- 1.9.0: Now sorts selected JSON text, even if that is embedded in a JSON object - note, doesn't preserve indents.
+- 1.8.0: Sorts objects within arrays.
 
-# Example
+## Example
 
 ![Example](resources/usage.gif)
 
-# Settings
+## Settings
 
-* You can override the sort order (note: this applies to all levels and overrides reverse sort too). Add this to your preferences (settings.json):
-    * `"sortJSON.orderOverride": ["name", "version", "description"]`
-* You can underride the sort order (note: this applies to all levels and underrides reverse sort too). Add this to your preferences (settings.json):
-    * `"sortJSON.orderUnderride": ["dependencies", "devDependencies"]`
+- You can override the sort order (note: this applies to all levels and overrides reverse sort too). Add this to your preferences (settings.json):
+  - `"sortJSON.orderOverride": ["name", "version", "description"]`
+- You can underride the sort order (note: this applies to all levels and underrides reverse sort too). Add this to your preferences (settings.json):
+  - `"sortJSON.orderUnderride": ["dependencies", "devDependencies"]`
+
+### Sort on save
+
+There's a vscode setting for formatters (`settings.json`):
+
+```json
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  }
+```
+
+But you can also selectively enable/disable this formatter with:
+
+```json
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.sortJSON": true
+  }
+}
+```
+
+Or use a hotkey, if you prefer (`keybindings.json`):
+
+```json
+{
+  "key": "cmd+shift+a",
+  "command": "editor.action.codeAction",
+  "args": {
+      "kind": "source.fixAll.sortJSON"
+  }
+}
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,9 +45,56 @@ function activate(context) {
         )
     ];
 
-    commands.forEach(function(command) {
+    commands.forEach(function (command) {
         context.subscriptions.push(command);
     });
+
+    context.subscriptions.push(
+        vscode.languages.registerCodeActionsProvider(
+            { language: "json", scheme: "file" },
+            new FixAllProvider(),
+            FixAllProvider.metadata
+        )
+    );
+}
+
+class FixAllProvider {
+    static fixAllCodeActionKind = vscode.CodeActionKind.SourceFixAll.append(
+        "sortJSON"
+    );
+
+    static metadata = {
+        providedCodeActionKinds: [FixAllProvider.fixAllCodeActionKind]
+    };
+
+    async provideCodeActions(document, _range, context, _token) {
+        if (!context.only) {
+            return [];
+        }
+
+        if (
+            !context.only.contains(FixAllProvider.fixAllCodeActionKind) &&
+            !FixAllProvider.fixAllCodeActionKind.contains(context.only)
+        ) {
+            return [];
+        }
+
+        const fixAllAction = await vscode.commands.executeCommand(
+            "sortJSON.sortJSON"
+        );
+
+        if (!fixAllAction) {
+            return [];
+        }
+
+        return [
+            {
+                ...fixAllAction,
+                title: "Fix All sortJSON",
+                kind: FixAllProvider.fixAllCodeActionKind
+            }
+        ];
+    }
 }
 
 exports.activate = activate;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-sort-json",
-    "version": "1.17.0",
+    "version": "1.18.0",
     "description": "Sorts the keys within JSON objects",
     "publisher": "richie5um2",
     "author": "Rich Somerfield",
@@ -48,7 +48,8 @@
         "onCommand:sortJSON.sortJSONValues",
         "onCommand:sortJSON.sortJSONValuesReverse",
         "onCommand:sortJSON.sortJSONType",
-        "onCommand:sortJSON.sortJSONTypeReverse"
+        "onCommand:sortJSON.sortJSONTypeReverse",
+        "onLanguage:json"
     ],
     "contributes": {
         "commands": [


### PR DESCRIPTION
> fix #22, fix #37

Makes it work as a formatter, so files can now be automatically sorted:

![Untitled](https://user-images.githubusercontent.com/13215662/94406656-c9a44500-018b-11eb-9888-27c461bcb687.gif)

Functionality is pretty limited though, since it only calls standard `SortJSON`, i.e. reverse options, etc., - are not available.

Aside main functionality, there's a little bunch of other fixes:

- Add .prettierrc.json, which follows already existing tab indentations, etc. ([You still don't use it?](https://prettier.io))
- Update README.md with related functionality
- Update README.md to make it more semantic (replace multiple h1 with h2, etc.)
- Bumps version to 1.18.0