### PR TITLE
Try to sort selected key/value pairs within object by wrapping in braces

### DIFF
--- a/lib/sort-json.js
+++ b/lib/sort-json.js
@@ -49,45 +49,61 @@ function findIndent(textEditor) {
 function sortActiveSelection(comparator, sortAlgo) {
     sortAlgo = sortAlgo || "alphabetical";
 
-    try {
-        sortActiveSelectionInternal(JSONC, JSONC, comparator, sortAlgo);
-        return true;
-    } catch (e) {
+    var wrapBraces = false;
+    var parserInput = JSONC;
+    var parserOutput = JSONC;
 
+    // returns true if we should try again or not
+    function handleError(e) {
+        if (!wrapBraces && sorter.startsWith(e.message, "Unexpected token : in JSON at position")) {
+            wrapBraces = true;
+            return true;
+        }
+
+        if (!Object.is(parserInput, JSON)) {
+            parserInput = JSON;
+            parserOutput = JSON;
+            return true;
+        }
+
+        var shouldTryJson5 = (
+            sorter.startsWith(
+                e.message,
+                "Unexpected token } in JSON at position"
+            ) ||
+            sorter.startsWith(
+                e.message,
+                "Unexpected token / in JSON at position"
+            )
+        );
+
+        if (!Object.is(parserInput, JSON5) && shouldTryJson5) {
+            parserInput = JSON5;
+            return true;
+        }
+
+        if (!Object.is(parserOutput, JSON5) && shouldTryJson5) {
+            parserOutput = JSON5;
+            return true;
+        }
+
+        return false;
+    };
+
+    var lastErr = undefined;
+    var tryAgain = true;
+    while (tryAgain) {
         try {
-
-            sortActiveSelectionInternal(JSON, JSON, comparator, sortAlgo);
+            sortActiveSelectionInternal(parserInput, parserOutput, comparator, sortAlgo, wrapBraces);
             return true;
         } catch (e) {
-            // Try to handle minor cases of incorrect JSON.
-
-            // This is when there is a trailing comma at the end of a JSON object
-            if (
-                sorter.startsWith(
-                    e.message,
-                    "Unexpected token } in JSON at position"
-                ) ||
-                sorter.startsWith(
-                    e.message,
-                    "Unexpected token / in JSON at position"
-                )
-            ) {
-                try {
-                    sortActiveSelectionInternal(JSON5, JSON, comparator, sortAlgo);
-                    return true;
-                } catch (e) { }
-            }
-
-            // Nothing else has worked, so lets try the full JSON5 parser and exporter.
-            try {
-                sortActiveSelectionInternal(JSON5, JSON5, comparator, sortAlgo);
-                return true;
-            } catch (e) {
-                console.log(e);
-                return false;
-            }
+            lastErr = e;
+            tryAgain = handleError(e);
         }
     }
+
+    console.log(lastErr);
+    return false;
 }
 
 function setSelection(
@@ -98,7 +114,7 @@ function setSelection(
     endPos,
     sortedText
 ) {
-    textEditor.edit(function(editBuilder) {
+    textEditor.edit(function (editBuilder) {
         var range = new vscode.Range(startLine, startPos, endLine, endPos);
         editBuilder.replace(range, sortedText);
     });
@@ -108,7 +124,8 @@ function sortActiveSelectionInternal(
     jsonParserInput,
     jsonParserOutput,
     sortOrder,
-    sortAlgo
+    sortAlgo,
+    wrapWithBraces,
 ) {
     var textEditor = vscode.window.activeTextEditor;
     var selection = textEditor.selection;
@@ -155,6 +172,12 @@ function sortActiveSelectionInternal(
         endLine,
         endPos
     );
+
+    if (wrapWithBraces) {
+        // TODO: would it be useful to also try wrapping with `[]`?
+        selectedText = "{" + selectedText.trimEnd() + "}";
+    }
+
     var initialJSON = sorter.textToJSON(jsonParserInput, selectedText);
     var sortedJSON = sorter.sortJSON(
         initialJSON,
@@ -165,6 +188,13 @@ function sortActiveSelectionInternal(
 
     var indent = findIndent(textEditor);
     var sortedText = sorter.jsonToText(jsonParserOutput, sortedJSON, indent);
+
+    if (wrapWithBraces) {
+        sortedText = sortedText.substring(1, sortedText.length - 1).trimEnd();
+        if (selectedText.endsWith(",}")) {
+            sortedText += ",";
+        }
+    }
 
     setSelection(textEditor, startLine, startPos, endLine, endPos, sortedText);
 }


### PR DESCRIPTION
It seems there are some use cases that make it useful to select and sort a subset of a JSON object, instead of the needing a whole object. I myself have wished for a feature like this and it seems some people have also requested it (#57 and maybe some others).

As a proof-of-concept, I thought maybe we could just try surrounding the selection in `{}` and sort that, and if it works then strip off the `{}` and return the result!

The result is this PR, which I'll leave as a draft just to see if there's interest in taking a change like this. I haven't tested all kinds of corner cases yet, so it's possible this breaks something, but I think the basic concept is there! I was able to format the example in the above issue as well as some entries in my VSCode `settings.json` (one of the main use cases I had for this feature).